### PR TITLE
Only add a watch if ngDisabled is present

### DIFF
--- a/directive.js
+++ b/directive.js
@@ -149,9 +149,11 @@ angular.module('rorymadden.date-dropdowns', [])
       }
 
       // pass down the ng-disabled property
-      scope.$parent.$watch(attrs.ngDisabled, function(newVal){
-        scope.disableFields = newVal;
-      });
+      if(attrs.ngDisabled) {
+        scope.$parent.$watch(attrs.ngDisabled, function(newVal){
+          scope.disableFields = newVal;
+        });
+      }
 
 
       var validator = function(){


### PR DESCRIPTION
This allows the script to work when one does not need to specify ngDisabled.
